### PR TITLE
Add interface for getting native window handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ out/
 # Vim
 /*.swp
 *.app
+
+/build/

--- a/README.md
+++ b/README.md
@@ -236,13 +236,13 @@ desktop UI applications in Go.
 
 ### Common pitfalls
 
-- When you run an app bundle with `open app.bundle`, OSX launch services
+- When you run an app bundle with `open Foo.app`, OSX launch services
   discards standard output and standard error. If you need to see
   this output for debugging purposes, use a redirect:
   ```
   gallium.RedirectStdoutStderr("output.log")
   ```
-- When you run an app bundle with `open app.bundle`, OSX launch services
+- When you run an app bundle with `open Foo.app`, OSX launch services
   will only start your app if there is not already another instance
   of the same application running, so if your app refuses to start then
   try checking the activity monitor for an already running instance.

--- a/app.go
+++ b/app.go
@@ -255,3 +255,9 @@ func (w *Window) CloseDevTools() {
 func (w *Window) DevToolsAreOpen() bool {
 	return bool(C.GalliumWindowDevToolsAreOpen(w.c))
 }
+
+// NativeWindow gets a operating-system dependent handle for this window. Under macOS
+// this is *NSWindow.
+func (w *Window) NativeWindow() unsafe.Pointer {
+	return unsafe.Pointer(C.GalliumWindowHandle(w.c))
+}

--- a/app.go
+++ b/app.go
@@ -257,7 +257,13 @@ func (w *Window) DevToolsAreOpen() bool {
 }
 
 // NativeWindow gets a operating-system dependent handle for this window. Under macOS
-// this is *NSWindow.
+// this is NSWindow*.
 func (w *Window) NativeWindow() unsafe.Pointer {
-	return unsafe.Pointer(C.GalliumWindowHandle(w.c))
+	return unsafe.Pointer(C.GalliumWindowNativeWindow(w.c))
+}
+
+// NativeWindow gets an operating-system dependent handle for the window controller.
+// Under macOS this is *NSWindowController.
+func (w *Window) NativeController() unsafe.Pointer {
+	return unsafe.Pointer(C.GalliumWindowNativeController(w.c))
 }

--- a/dist/Gallium.framework/Versions/A/Gallium
+++ b/dist/Gallium.framework/Versions/A/Gallium
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92f7cc42d817b481230a7150bf313fbe43d8ed29fa9c80ebba6056affd9ca4ce
-size 1191096
+oid sha256:f221c9958a8fd98b4a7b34d2aced43a2470f8c900b99ee40454207874af1a4b0
+size 1191560

--- a/dist/include/gallium/browser.h
+++ b/dist/include/gallium/browser.h
@@ -84,9 +84,18 @@ GALLIUM_EXPORT void GalliumWindowOpenDevTools(gallium_window_t* window);
 
 // GalliumWindowCloseDevTools closes the developer tools for the given window
 GALLIUM_EXPORT void GalliumWindowCloseDevTools(gallium_window_t* window);
-
+  
 // GalliumWindowDevToolsVisible returns true if the developer tools are currently visible for the given window
 GALLIUM_EXPORT bool GalliumWindowDevToolsAreOpen(gallium_window_t* window);
+  
+// GalliumWindowNativeWindow gets a native handle for this window (NSWindow*).
+GALLIUM_EXPORT void* GalliumWindowNativeWindow(gallium_window_t* window);
+
+// GalliumWindowNativeWindow gets a native handle for the window controller (NSWindowController*).
+GALLIUM_EXPORT void* GalliumWindowNativeController(gallium_window_t* window);
+
+// GalliumWindowNativeWindow gets a native handle for the window content (content::WebContent*).
+GALLIUM_EXPORT void* GalliumWindowNativeContent(gallium_window_t* window);
   
 #ifdef __cplusplus
 }

--- a/examples/native/native.go
+++ b/examples/native/native.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log"
+	"os"
+	"runtime"
+
+	"github.com/alexflint/gallium"
+)
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -framework Cocoa
+#cgo LDFLAGS: -framework Cocoa
+
+#include <Cocoa/Cocoa.h>
+#include <dispatch/dispatch.h>
+
+void SetAlpha(void* window, float alpha) {
+  // Cocoa requires that all UI operations happen on the main thread. Since
+  // gallium.Loop will have initiated the Cocoa event loop, we can can use
+  // dispatch_async to run code on the main thread.
+  dispatch_async(dispatch_get_main_queue(), ^{
+	NSWindow* w = (NSWindow*)window;
+	[w setAlphaValue:alpha];
+  });
+}
+*/
+import "C"
+
+func onReady(ui *gallium.App) {
+	window, err := ui.OpenWindow("http://www.example.com/", gallium.FramedWindow)
+	if err != nil {
+		log.Fatal(err)
+	}
+	C.SetAlpha(window.NativeWindow(), 0.5)
+}
+
+func main() {
+	runtime.LockOSThread()
+	gallium.RedirectStdoutStderr(os.ExpandEnv("$HOME/Library/Logs/Gallium.log"))
+	gallium.Loop(os.Args, onReady)
+}

--- a/examples/native/native.go
+++ b/examples/native/native.go
@@ -29,7 +29,7 @@ void SetAlpha(void* window, float alpha) {
 import "C"
 
 func onReady(ui *gallium.App) {
-	window, err := ui.OpenWindow("http://www.example.com/", gallium.FramedWindow)
+	window, err := ui.OpenWindow("http://example.com/", gallium.FramedWindow)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This pr makes it possible to get native window handles from gallium, and manipulate them in cgo code. There is an example that shows how to change the alpha value of a window by via `[NSWindow setAlphaValue:]`.

The reason to expose the native handles at all is that each platform's windowing API is very deep, and while gallium will provide a platform-independent abstraction layer over the most common use case, we will never cover every possible thing that you can do via native APIs.

Depends on #34 
