### PR TITLE
Add cut, copy, paste, etc to window API

### DIFF
--- a/app.go
+++ b/app.go
@@ -32,6 +32,11 @@ import (
 	"unsafe"
 )
 
+var (
+	errZeroWidth  = errors.New("window width was zero")
+	errZeroHeight = errors.New("window height was zero")
+)
+
 // cerr holds a C-allocated error, which must be freed explicitly.
 type cerr struct {
 	c *C.struct_gallium_error
@@ -155,11 +160,6 @@ type Window struct {
 	c *C.gallium_window_t
 }
 
-var (
-	errZeroWidth  = errors.New("window width was zero")
-	errZeroHeight = errors.New("window height was zero")
-)
-
 // OpenWindow creates a window that will load the given URL.
 func (app *App) OpenWindow(url string, opt WindowOptions) (*Window, error) {
 	if opt.Shape.Width == 0 {
@@ -239,6 +239,51 @@ func (w *Window) Close() {
 // Miniaturize miniaturizes the window, as if the min button had been clicked.
 func (w *Window) Miniaturize() {
 	C.GalliumWindowMiniaturize(w.c)
+}
+
+// Undo undoes the last text editing action
+func (w *Window) Undo() {
+	C.GalliumWindowUndo(w.c)
+}
+
+// Redo redoes the last text editing action
+func (w *Window) Redo() {
+	C.GalliumWindowRedo(w.c)
+}
+
+// Cut cuts the current text selection to the pastboard
+func (w *Window) Cut() {
+	C.GalliumWindowCut(w.c)
+}
+
+// Copy copies the current text selection to the pasteboard
+func (w *Window) Copy() {
+	C.GalliumWindowCopy(w.c)
+}
+
+// Paste pastes from the pasteboard
+func (w *Window) Paste() {
+	C.GalliumWindowPaste(w.c)
+}
+
+// PasteAndMatchStyle pastes from the pasteboard, matching style to the current element
+func (w *Window) PasteAndMatchStyle() {
+	C.GalliumWindowPasteAndMatchStyle(w.c)
+}
+
+// Delete deletes the current text selection
+func (w *Window) Delete() {
+	C.GalliumWindowDelete(w.c)
+}
+
+// SelectAll selects all text in the current element
+func (w *Window) SelectAll() {
+	C.GalliumWindowSelectAll(w.c)
+}
+
+// Unselect unselects any text selection
+func (w *Window) Unselect() {
+	C.GalliumWindowUnselect(w.c)
 }
 
 // OpenDevTools opens the developer tools for this window.

--- a/cocoa.go
+++ b/cocoa.go
@@ -24,7 +24,6 @@ static inline gallium_nsmenuitem_t* helper_NSMenu_AddMenuItem(
 		&cgo_onMenuClicked,
 		callbackArg);
 }
-
 */
 import "C"
 import (

--- a/cocoa.go
+++ b/cocoa.go
@@ -111,7 +111,7 @@ func parseShortcut(s string) (key string, modifiers int, err error) {
 		case "cmd":
 			modifiers |= int(C.GalliumCmdModifier)
 		case "ctrl":
-			modifiers |= int(C.GalliumCmdModifier)
+			modifiers |= int(C.GalliumCtrlModifier)
 		case "cmdctrl":
 			modifiers |= int(C.GalliumCmdOrCtrlModifier)
 		case "alt":

--- a/dist/Gallium.framework/Versions/A/Gallium
+++ b/dist/Gallium.framework/Versions/A/Gallium
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f221c9958a8fd98b4a7b34d2aced43a2470f8c900b99ee40454207874af1a4b0
-size 1191560
+oid sha256:f59c26bc0a08e8e64f2239c69b454bb2590f4ae2b583b275ab84d6c1d19cc47e
+size 1178684

--- a/dist/Gallium.framework/Versions/A/Gallium
+++ b/dist/Gallium.framework/Versions/A/Gallium
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f59c26bc0a08e8e64f2239c69b454bb2590f4ae2b583b275ab84d6c1d19cc47e
-size 1178684
+oid sha256:31f9d1e0d815b80fce3eb3592e23b02abc7972b88402d149fae92e739d35f2ac
+size 1192128

--- a/dist/include/gallium/browser.h
+++ b/dist/include/gallium/browser.h
@@ -79,6 +79,33 @@ GALLIUM_EXPORT void GalliumWindowClose(gallium_window_t* window);
 // GalliumWindowClose miniaturizes the window
 GALLIUM_EXPORT void GalliumWindowMiniaturize(gallium_window_t* window);
 
+// GalliumWindowUndo undoes the last text editing action
+GALLIUM_EXPORT void GalliumWindowUndo(gallium_window_t* window);
+
+// GalliumWindowRedo redoes the last text editing action
+GALLIUM_EXPORT void GalliumWindowRedo(gallium_window_t* window);
+
+// GalliumWindow cuts the current text selection to the pastboard
+GALLIUM_EXPORT void GalliumWindowCut(gallium_window_t* window);
+
+// GalliumWindow copies the current text selection to the pasteboard
+GALLIUM_EXPORT void GalliumWindowCopy(gallium_window_t* window);
+
+// GalliumWindow pastes from the pasteboard
+GALLIUM_EXPORT void GalliumWindowPaste(gallium_window_t* window);
+
+// GalliumWindow pastes from the pasteboard, matching style to the current element
+GALLIUM_EXPORT void GalliumWindowPasteAndMatchStyle(gallium_window_t* window);
+
+// GalliumWindow deletes the current text selection
+GALLIUM_EXPORT void GalliumWindowDelete(gallium_window_t* window);
+
+// GalliumWindow selects all text in the current element
+GALLIUM_EXPORT void GalliumWindowSelectAll(gallium_window_t* window);
+
+// GalliumWindowUnselect unselects any text selection
+GALLIUM_EXPORT void GalliumWindowUnselect(gallium_window_t* window);
+
 // GalliumWindowOpenDevTools opens the developer tools for the given window
 GALLIUM_EXPORT void GalliumWindowOpenDevTools(gallium_window_t* window);
 


### PR DESCRIPTION
This pr adds the common edit menu commands to the window API:
- undo
- redo
- cut
- copy
- past
- past and match style
- select all
- delete
- unselect

It also fixes some small issues:
- deadlock in OpenWindow when Go code is running from the UI thread
- the modifier mask for command was swapped with control