### PR TITLE
add screen API

### DIFF
--- a/app.go
+++ b/app.go
@@ -107,14 +107,6 @@ type App struct {
 	ready chan struct{}
 }
 
-// Rect represents a rectangular region on the screen
-type Rect struct {
-	Width  int // Width in pixels
-	Height int // Height in pixels
-	Left   int // Left is offset from left in pixel
-	Top    int // Left is offset from top in pixels
-}
-
 // WindowOptions contains options for creating windows
 type WindowOptions struct {
 	Title            string // String to display in title bar
@@ -135,7 +127,7 @@ var FramedWindow = WindowOptions{
 		Width:  800,
 		Height: 600,
 		Left:   100,
-		Top:    100,
+		Bottom: 100,
 	},
 	TitleBar:         true,
 	Frame:            true,
@@ -169,7 +161,7 @@ var FramelessWindow = WindowOptions{
 		Width:  800,
 		Height: 600,
 		Left:   100,
-		Top:    100,
+		Bottom: 100,
 	},
 	Resizable: true,
 }
@@ -194,7 +186,7 @@ func (app *App) OpenWindow(url string, opt WindowOptions) (*Window, error) {
 		C.int(opt.Shape.Width),
 		C.int(opt.Shape.Height),
 		C.int(opt.Shape.Left),
-		C.int(opt.Shape.Top),
+		C.int(opt.Shape.Bottom),
 		C.bool(opt.TitleBar),
 		C.bool(opt.Frame),
 		C.bool(opt.Resizable),
@@ -210,17 +202,12 @@ func (app *App) OpenWindow(url string, opt WindowOptions) (*Window, error) {
 
 // Shape gets the current shape of the window.
 func (w *Window) Shape() Rect {
-	return Rect{
-		Width:  int(C.GalliumWindowGetWidth(w.c)),
-		Height: int(C.GalliumWindowGetHeight(w.c)),
-		Left:   int(C.GalliumWindowGetLeft(w.c)),
-		Top:    int(C.GalliumWindowGetTop(w.c)),
-	}
+	return rectFromC(C.GalliumWindowGetShape(w.c))
 }
 
 // Shape gets the current shape of the window.
 func (w *Window) SetShape(r Rect) {
-	C.GalliumWindowSetShape(w.c, C.int(r.Width), C.int(r.Height), C.int(r.Left), C.int(r.Top))
+	C.GalliumWindowSetShape(w.c, C.int(r.Width), C.int(r.Height), C.int(r.Left), C.int(r.Bottom))
 }
 
 // URL gets the URL that the window is currently at.

--- a/dist/Gallium.framework/Versions/A/Gallium
+++ b/dist/Gallium.framework/Versions/A/Gallium
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:788b1d2c13c4c7a175b426d3dd74a9091300d657059a68f31fe47eec27a4897f
+oid sha256:01acad771a6202bf17ea82433ab52135c952ade3f614c223e0e60938ba7b69a6
 size 1197656

--- a/dist/Gallium.framework/Versions/A/Gallium
+++ b/dist/Gallium.framework/Versions/A/Gallium
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a76a80d79a6dd496cfc03e933b9da14bc505a74b6c13cacd5fcb598815222124
-size 1192488
+oid sha256:788b1d2c13c4c7a175b426d3dd74a9091300d657059a68f31fe47eec27a4897f
+size 1197656

--- a/dist/Gallium.framework/Versions/A/Gallium
+++ b/dist/Gallium.framework/Versions/A/Gallium
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01acad771a6202bf17ea82433ab52135c952ade3f614c223e0e60938ba7b69a6
+oid sha256:65840a2a9b13113151794e772b54c194a9439483fabce3c64ca9c4b1c8fb6d62
 size 1197656

--- a/dist/include/gallium/browser.h
+++ b/dist/include/gallium/browser.h
@@ -1,18 +1,14 @@
-#ifndef GALLIUM_API_GALLIUM_H_
-#define GALLIUM_API_GALLIUM_H_
+#ifndef GALLIUM_BROWSER_H_
+#define GALLIUM_BROWSER_H_
 
 #include <stdbool.h>
+
+#include "gallium/export.h"
+#include "gallium/rect.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define GALLIUM_EXPORT __attribute__ ((visibility ("default")))
-
-// gallium_error represents an error
-typedef struct GALLIUM_EXPORT gallium_error {
-	const char* msg;
-} gallium_error_t;
 
 // gallium_window represents a window
 typedef struct GALLIUM_EXPORT gallium_window gallium_window_t;
@@ -40,16 +36,7 @@ GALLIUM_EXPORT gallium_window_t* GalliumOpenWindow(const char* url,
 
   
 // GalliumWindowGetWidth gets the width of a window
-GALLIUM_EXPORT int GalliumWindowGetWidth(gallium_window_t* window);
-
-// GalliumWindowGetWidth gets the width of a window
-GALLIUM_EXPORT int GalliumWindowGetHeight(gallium_window_t* window);
-
-// GalliumWindowGetWidth gets the width of a window
-GALLIUM_EXPORT int GalliumWindowGetLeft(gallium_window_t* window);
-
-// GalliumWindowGetWidth gets the width of a window
-GALLIUM_EXPORT int GalliumWindowGetTop(gallium_window_t* window);
+GALLIUM_EXPORT gallium_rect_t GalliumWindowGetShape(gallium_window_t* window);
 
 // GalliumWindowGetWidth gets the width of a window
 GALLIUM_EXPORT void GalliumWindowSetShape(gallium_window_t* window,
@@ -128,4 +115,4 @@ GALLIUM_EXPORT void* GalliumWindowNativeContent(gallium_window_t* window);
 }
 #endif
 
-#endif
+#endif // ifndef GALLIUM_BROWSER_H_

--- a/dist/include/gallium/cocoa.h
+++ b/dist/include/gallium/cocoa.h
@@ -1,9 +1,10 @@
-#ifndef GALLIUM_API_COCOA_H_
-#define GALLIUM_API_COCOA_H_
+#ifndef GALLIUM_COCOA_H_
+#define GALLIUM_COCOA_H_
 
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "gallium/export.h"
 #include "gallium/browser.h"
 
 #ifdef __cplusplus
@@ -81,4 +82,4 @@ GALLIUM_EXPORT char* MainBundle_ObjectForKey(const char* key);
 }
 #endif
 
-#endif
+#endif // ifndef GALLIUM_COCOA_H_

--- a/dist/include/gallium/export.h
+++ b/dist/include/gallium/export.h
@@ -1,0 +1,23 @@
+#ifndef GALLIUM_EXPORT_H_
+#define GALLIUM_EXPORT_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GALLIUM_EXPORT __attribute__ ((visibility ("default")))
+
+// gallium_error represents an error
+typedef struct GALLIUM_EXPORT gallium_error {
+	const char* msg;
+} gallium_error_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ifndef GALLIUM_EXPORT_H_
+

--- a/dist/include/gallium/rect.h
+++ b/dist/include/gallium/rect.h
@@ -1,0 +1,22 @@
+#ifndef GALLIUM_RECT_H_
+#define GALLIUM_RECT_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct GALLIUM_EXPORT {
+	int width;
+	int height;
+	int left;
+	int bottom;
+} gallium_rect_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ifndef GALLIUM_RECT_H_

--- a/dist/include/gallium/screen.h
+++ b/dist/include/gallium/screen.h
@@ -19,7 +19,7 @@ GALLIUM_EXPORT int GalliumScreenCount();
 // GalliumScreen gets the i-th screen
 GALLIUM_EXPORT gallium_screen_t* GalliumScreen(int index);
 
-// GalliumFocusedScreen gets the screen containing the currently focused window.
+// GalliumFocusedScreen gets the screen containing the currently focussed window.
 GALLIUM_EXPORT gallium_screen_t* GalliumFocusedScreen();
 
 // GalliumScreenShape gets the shape of a screen

--- a/dist/include/gallium/screen.h
+++ b/dist/include/gallium/screen.h
@@ -19,8 +19,8 @@ GALLIUM_EXPORT int GalliumScreenCount();
 // GalliumScreen gets the i-th screen
 GALLIUM_EXPORT gallium_screen_t* GalliumScreen(int index);
 
-// GalliumFocussedScreen gets the screen containing the currently focussed window.
-GALLIUM_EXPORT gallium_screen_t* GalliumFocussedScreen();
+// GalliumFocusedScreen gets the screen containing the currently focused window.
+GALLIUM_EXPORT gallium_screen_t* GalliumFocusedScreen();
 
 // GalliumScreenShape gets the shape of a screen
 GALLIUM_EXPORT gallium_rect_t GalliumScreenShape(gallium_screen_t*);

--- a/dist/include/gallium/screen.h
+++ b/dist/include/gallium/screen.h
@@ -1,0 +1,41 @@
+#ifndef GALLIUM_SCREEN_H_
+#define GALLIUM_SCREEN_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "gallium/export.h"
+#include "gallium/rect.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct GALLIUM_EXPORT gallium_screen gallium_screen_t;
+
+// GalliumScreenCount gets the number of screens
+GALLIUM_EXPORT int GalliumScreenCount();
+
+// GalliumScreen gets the i-th screen
+GALLIUM_EXPORT gallium_screen_t* GalliumScreen(int index);
+
+// GalliumFocussedScreen gets the screen containing the currently focussed window.
+GALLIUM_EXPORT gallium_screen_t* GalliumFocussedScreen();
+
+// GalliumScreenShape gets the shape of a screen
+GALLIUM_EXPORT gallium_rect_t GalliumScreenShape(gallium_screen_t*);
+
+// GalliumScreenShape gets the usable area of a screen (excludes dock and menubar)
+GALLIUM_EXPORT gallium_rect_t GalliumScreenUsable(gallium_screen_t*);
+
+// GalliumScreenBitsPerPixel gets the bits per pixels for a screen
+GALLIUM_EXPORT int GalliumScreenBitsPerPixel(gallium_screen_t*);
+
+// GalliumScreenID gets the unique ID for a screen
+GALLIUM_EXPORT int GalliumScreenID(gallium_screen_t*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ifndef GALLIUM_SCREEN_H_

--- a/examples/screens/screens.go
+++ b/examples/screens/screens.go
@@ -11,7 +11,6 @@ import (
 func onReady(app *gallium.App) {
 	pretty.Println(gallium.FocusedScreen())
 	pretty.Println(gallium.Screens())
-	x
 }
 
 func main() {

--- a/examples/screens/screens.go
+++ b/examples/screens/screens.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/alexflint/gallium"
+	"github.com/kr/pretty"
+)
+
+func onReady(app *gallium.App) {
+	pretty.Println(gallium.FocusedScreen())
+	pretty.Println(gallium.Screens())
+	x
+}
+
+func main() {
+	runtime.LockOSThread()
+	gallium.RedirectStdoutStderr(os.ExpandEnv("$HOME/Library/Logs/Gallium.log"))
+	gallium.Loop(os.Args, onReady)
+}

--- a/rect.go
+++ b/rect.go
@@ -1,0 +1,28 @@
+package gallium
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.8
+#cgo CFLAGS: -DGALLIUM_DIR=${SRCDIR}
+#cgo CFLAGS: -Idist/include
+
+#include <stdlib.h>
+#include "gallium/rect.h"
+*/
+import "C"
+
+// Rect represents a rectangular region on the screen
+type Rect struct {
+	Width  int // Width in pixels
+	Height int // Height in pixels
+	Left   int // Left is offset from left in pixel
+	Bottom int // Left is offset from top in pixels
+}
+
+func rectFromC(c C.gallium_rect_t) Rect {
+	return Rect{
+		Width:  int(c.width),
+		Height: int(c.height),
+		Left:   int(c.left),
+		Bottom: int(c.bottom),
+	}
+}

--- a/screen.go
+++ b/screen.go
@@ -1,0 +1,58 @@
+package gallium
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.8
+#cgo CFLAGS: -DGALLIUM_DIR=${SRCDIR}
+#cgo CFLAGS: -Idist/include
+
+#include <stdlib.h>
+#include "gallium/screen.h"
+*/
+import "C"
+import "fmt"
+
+// A screen represents a physical rectangular display. "Device coordinates"
+// means a position on a screen measured from (0, 0) at the bottom left of
+// the device. "Global coordinates" means the coordinate system in which
+// each of the screens are positioned relative to each other. Global and
+// device coordinates almost always have the same scale factor. It is
+// possible for screens to overlap in global coordinates (such as when
+// mirroring a display.)
+type Screen struct {
+	Shape        Rect // the size and position of this screen in global coords
+	Usable       Rect // excludes the menubar and dock
+	BitsPerPixel int  // color depth of this screen (total of all color components)
+	ID           int  // unique identifier for this screen
+}
+
+func screenFromC(c *C.gallium_screen_t) Screen {
+	return Screen{
+		Shape:        rectFromC(C.GalliumScreenShape(c)),
+		Usable:       rectFromC(C.GalliumScreenUsable(c)),
+		BitsPerPixel: int(C.GalliumScreenBitsPerPixel(c)),
+		ID:           int(C.GalliumScreenID(c)),
+	}
+}
+
+// Screens gets a list of available screens
+func Screens() []Screen {
+	var screens []Screen
+	n := int(C.GalliumScreenCount())
+	for i := 0; i < n; i++ {
+		c := C.GalliumScreen(C.int(i))
+		if c == nil {
+			panic(fmt.Sprintf("GalliumScreen returned nil for index %d", i))
+		}
+		screens = append(screens, screenFromC(c))
+	}
+	return screens
+}
+
+// FocussedScreen gets the screen containing the currently focussed window
+func FocussedScreen() Screen {
+	c := C.GalliumFocussedScreen()
+	if c == nil {
+		panic("GalliumFocussedScreen returned nil")
+	}
+	return screenFromC(c)
+}

--- a/screen.go
+++ b/screen.go
@@ -11,13 +11,13 @@ package gallium
 import "C"
 import "fmt"
 
-// A screen represents a physical rectangular display. "Device coordinates"
-// means a position on a screen measured from (0, 0) at the bottom left of
-// the device. "Global coordinates" means the coordinate system in which
-// each of the screens are positioned relative to each other. Global and
-// device coordinates almost always have the same scale factor. It is
-// possible for screens to overlap in global coordinates (such as when
-// mirroring a display.)
+// A screen represents a rectangular display, normally corresponding to a
+// physical display. "Device coordinates" means a position on a screen
+// measured from (0, 0) at the bottom left of the device. "Global coordinates"
+// means the coordinate system in which each of the screens are positioned
+// relative to each other. Global and device coordinates almost always have
+// the same scale factor. It is possible for screens to overlap in global
+// coordinates (such as when mirroring a display.)
 type Screen struct {
 	Shape        Rect // the size and position of this screen in global coords
 	Usable       Rect // excludes the menubar and dock
@@ -48,11 +48,11 @@ func Screens() []Screen {
 	return screens
 }
 
-// FocussedScreen gets the screen containing the currently focussed window
-func FocussedScreen() Screen {
-	c := C.GalliumFocussedScreen()
+// FocusedScreen gets the screen containing the currently focused window
+func FocusedScreen() Screen {
+	c := C.GalliumFocusedScreen()
 	if c == nil {
-		panic("GalliumFocussedScreen returned nil")
+		panic("GalliumFocusedScreen returned nil")
 	}
 	return screenFromC(c)
 }


### PR DESCRIPTION
This pr adds the following API for getting the size and position of each available screen:

```
// A screen represents a rectangular display, normally corresponding to a
// physical display. "Device coordinates" means a position on a screen
// measured from (0, 0) at the bottom left of the device. "Global coordinates"
// means the coordinate system in which each of the screens are positioned
// relative to each other. Global and device coordinates almost always have
// the same scale factor. It is possible for screens to overlap in global 
// coordinates (such as when mirroring a display.)
type Screen struct {
	 Shape        Rect // the size and position of this screen in global coords
	 Usable       Rect // excludes the menubar and dock
	 BitsPerPixel int  // color depth of this screen (total of all color components)
	 ID           int  // unique identifier for this screen
}

// Screens gets a list of available screens
func Screens() []Screen

// FocussedScreen gets the screen containing the currently focussed window
func FocussedScreen() Screen
```

As usual I will leave this open for 24 hours.